### PR TITLE
Fix invalid/mismatching URI, replacing it with custom namespace

### DIFF
--- a/TheCloud.lv2/TheCloud_dsp.ttl
+++ b/TheCloud.lv2/TheCloud_dsp.ttl
@@ -13,7 +13,7 @@
 @prefix spdx:  <http://spdx.org/rdf/terms#> .
 @prefix unit:  <http://lv2plug.in/ns/extensions/units#> .
 
-<urn:hvcc:TheCloud>
+<urn:sensorium-plugins:TheCloud>
     a lv2:Plugin, mod:DelayPlugin, doap:Project ;
 
     lv2:extensionData opts:interface ;

--- a/TheCloud.lv2/TheCloud_dsp.ttl
+++ b/TheCloud.lv2/TheCloud_dsp.ttl
@@ -75,7 +75,7 @@
         lv2:default 20 ;
         lv2:minimum 2 ;
         lv2:maximum 200 ;
-        lv2:portProperty lv2:logarithmic, 2, 20 ;
+        lv2:portProperty lv2:logarithmic ;
     ] ,
     [
         a lv2:InputPort, lv2:ControlPort ;

--- a/TheCloud.lv2/manifest.ttl
+++ b/TheCloud.lv2/manifest.ttl
@@ -1,9 +1,8 @@
 @prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-<urn:hvcc:TheCloud>
+<urn:sensorium-plugins:TheCloud>
     a lv2:Plugin ;
     lv2:binary <TheCloud_dsp.so> ;
-    rdfs:seeAlso <TheCloud_dsp.ttl> .
-
-<urn:hvcc:TheCloud> rdfs:seeAlso <modgui.ttl> .
+    rdfs:seeAlso <TheCloud_dsp.ttl> ,
+                 <modgui.ttl> .

--- a/TheCloud.lv2/modgui.ttl
+++ b/TheCloud.lv2/modgui.ttl
@@ -1,7 +1,7 @@
 @prefix modgui: <http://moddevices.com/ns/modgui#> .
 @prefix lv2:    <http://lv2plug.in/ns/lv2core#> .
 
-<urn:hvcc:TheCloud>
+<urn:sensorium-plugins:TheCloud>
     modgui:gui [
         modgui:resourcesDirectory <modgui> ;
         modgui:iconTemplate <modgui/icon-thecloud.html> ;

--- a/thecloud.json
+++ b/thecloud.json
@@ -4,13 +4,13 @@
         "description": "Granular delay ported from Pure Data using hvcc",
         "maker": "sensorium",
         "homepage": "https://github.com/sensorium/sensorium-plugins",
-        "plugin_uri": "lv2://sensorium-plugins/TheCloud",
+        "plugin_uri": "urn:sensorium-plugins:TheCloud",
         "version": "0, 0, 1",
         "license": "GPL3",
         "midi_input": 1,
         "midi_output": 0,
         "plugin_formats": [
-            "lv2_dsp"
+            "lv2_sep"
         ]
     }
 }


### PR DESCRIPTION
The URI "lv2://sensorium-plugins/TheCloud" specified on the json file is not valid and doesnt match the URI on the ttl files.
While we are tweaking it, we might as well use a custom namespace for the URI instead of the default "hvcc" one.
